### PR TITLE
Allow configurable 'no akamai header present' actions

### DIFF
--- a/src/main/scala/uk/gov/hmrc/whitelist/AkamaiWhitelistFilter.scala
+++ b/src/main/scala/uk/gov/hmrc/whitelist/AkamaiWhitelistFilter.scala
@@ -37,7 +37,8 @@ trait AkamaiWhitelistFilter extends Filter {
 
   def destination: Call
 
-  def noHeaderAction = { Future.successful(NotImplemented) }
+  def noHeaderAction(f: (RequestHeader) => Future[Result],
+                    rh: RequestHeader): Future[Result] = Future.successful(NotImplemented)
 
   override def apply
   (f: (RequestHeader) => Future[Result])
@@ -53,6 +54,6 @@ trait AkamaiWhitelistFilter extends Filter {
             Future.successful(Forbidden)
           else
             Future.successful(Redirect(destination))
-      } getOrElse noHeaderAction
+      } getOrElse noHeaderAction(f, rh)
     }
 }

--- a/src/main/scala/uk/gov/hmrc/whitelist/AkamaiWhitelistFilter.scala
+++ b/src/main/scala/uk/gov/hmrc/whitelist/AkamaiWhitelistFilter.scala
@@ -37,6 +37,8 @@ trait AkamaiWhitelistFilter extends Filter {
 
   def destination: Call
 
+  def noHeaderAction = { Future.successful(NotImplemented) }
+
   override def apply
   (f: (RequestHeader) => Future[Result])
   (rh: RequestHeader): Future[Result] =
@@ -51,6 +53,6 @@ trait AkamaiWhitelistFilter extends Filter {
             Future.successful(Forbidden)
           else
             Future.successful(Redirect(destination))
-      } getOrElse Future.successful(NotImplemented)
+      } getOrElse noHeaderAction
     }
 }

--- a/src/test/scala/uk/gov/hmrc/whitelist/AkamaiWhitelistFilterCommonSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/whitelist/AkamaiWhitelistFilterCommonSpec.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.whitelist
+
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatestplus.play.PlaySpec
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+
+trait AkamaiWhitelistFilterCommonSpec extends PlaySpec with ScalaFutures {
+
+  "AkamaiWhitelistFilter (Common)" must {
+    "return successfully when a valid `True-Client-IP` header is found" in {
+      val Some(result) = route(FakeRequest("GET", "/index").withHeaders(
+        "True-Client-IP" -> "127.0.0.1"
+      ))
+      status(result) must be(OK)
+      contentAsString(result) must be("success")
+    }
+
+    "return a `Redirect` when an invalid `True-Client-IP` header is found" in {
+      val Some(result) = route(FakeRequest("GET", "/index").withHeaders(
+        "True-Client-IP" -> "someotherip"
+      ))
+      status(result) must be(SEE_OTHER)
+      redirectLocation(result) must be(Some("/destination"))
+    }
+
+    "return `Forbidden` if the user would end up in a redirect loop" in {
+      val Some(result) = route(FakeRequest("GET", "/destination").withHeaders(
+        "True-Client-IP" -> "someotherip"
+      ))
+
+      status(result) mustBe FORBIDDEN
+    }
+
+    "return `Ok` if the route to be accessed is an excluded path" in {
+      val Some(result) = route(FakeRequest("GET", "/healthcheck"))
+
+      status(result) mustBe OK
+    }
+  }
+}

--- a/src/test/scala/uk/gov/hmrc/whitelist/AkamaiWhitelistFilterSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/whitelist/AkamaiWhitelistFilterSpec.scala
@@ -16,53 +16,16 @@
 
 package uk.gov.hmrc.whitelist
 
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatestplus.play.PlaySpec
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 
-class AkamaiWhitelistFilterSpec extends PlaySpec with TestApp with ScalaFutures {
+class AkamaiWhitelistFilterSpec extends AkamaiWhitelistFilterCommonSpec with TestApp {
 
   "AkamaiWhitelistFilter" must {
 
-    "return a `NotImplemented` by default when no `True-Client-IP` header is found" in {
-
+    "return a `NotImplemented` when no `True-Client-IP` header is found" in {
       val Some(result) = route(FakeRequest("GET", "/index"))
       status(result) must be (NOT_IMPLEMENTED)
-    }
-
-    "return successfully when a valid `True-Client-IP` header is found" in {
-
-      val Some(result) = route(FakeRequest("GET", "/index").withHeaders(
-        "True-Client-IP" -> "127.0.0.1"
-      ))
-      status(result) must be (OK)
-      contentAsString(result) must be ("success")
-    }
-
-    "return a `Redirect` when an invalid `True-Client-IP` header is found" in {
-
-      val Some(result) = route(FakeRequest("GET", "/index").withHeaders(
-        "True-Client-IP" -> "someotherip"
-      ))
-      status(result) must be (SEE_OTHER)
-      redirectLocation(result) must be (Some("/destination"))
-    }
-
-    "return `Forbidden` if the user would end up in a redirect loop" in {
-
-      val Some(result) = route(FakeRequest("GET", "/destination").withHeaders(
-        "True-Client-IP" -> "someotherip"
-      ))
-
-      status(result) mustBe FORBIDDEN
-    }
-
-    "return `Ok` if the route to be accessed is an excluded path" in {
-
-      val Some(result) = route(FakeRequest("GET", "/healthcheck"))
-
-      status(result) mustBe OK
     }
   }
 }

--- a/src/test/scala/uk/gov/hmrc/whitelist/AkamaiWhitelistFilterWithCustomFailureDefaultSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/whitelist/AkamaiWhitelistFilterWithCustomFailureDefaultSpec.scala
@@ -16,49 +16,17 @@
 
 package uk.gov.hmrc.whitelist
 
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatestplus.play.PlaySpec
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 
-class AkamaiWhitelistFilterWithCustomFailureDefaultSpec extends PlaySpec with TestAppWithCustomFailureDefault with ScalaFutures {
+class AkamaiWhitelistFilterWithCustomFailureDefaultSpec extends AkamaiWhitelistFilterCommonSpec with TestAppWithCustomFailureDefault {
 
   "AkamaiWhitelistFilter" must {
 
-    "return the custom response by default when no `True-Client-IP` header is found" in {
+    "return the success response when no `True-Client-IP` header is found" in {
       val Some(result) = route(FakeRequest("GET", "/index"))
       status(result) must be (OK)
       contentAsString(result) must be ("success")
     }
-
-    "return successfully when a valid `True-Client-IP` header is found" in {
-      val Some(result) = route(FakeRequest("GET", "/index").withHeaders(
-        "True-Client-IP" -> "127.0.0.1"
-      ))
-      status(result) must be (OK)
-      contentAsString(result) must be ("success")
-    }
-
-    "return a `Redirect` when an invalid `True-Client-IP` header is found" in {
-      val Some(result) = route(FakeRequest("GET", "/index").withHeaders(
-        "True-Client-IP" -> "someotherip"
-      ))
-      status(result) must be (SEE_OTHER)
-      redirectLocation(result) must be (Some("/destination"))
-    }
-
-    "return `Forbidden` if the user would end up in a redirect loop" in {
-      val Some(result) = route(FakeRequest("GET", "/destination").withHeaders(
-        "True-Client-IP" -> "someotherip"
-      ))
-
-      status(result) mustBe FORBIDDEN
-    }
-
-    "return `Ok` if the route to be accessed is an excluded path" in {
-      val Some(result) = route(FakeRequest("GET", "/healthcheck"))
-      status(result) mustBe OK
-    }
-
   }
 }

--- a/src/test/scala/uk/gov/hmrc/whitelist/AkamaiWhitelistFilterWithCustomFailureDefaultSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/whitelist/AkamaiWhitelistFilterWithCustomFailureDefaultSpec.scala
@@ -21,18 +21,17 @@ import org.scalatestplus.play.PlaySpec
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 
-class AkamaiWhitelistFilterSpec extends PlaySpec with TestApp with ScalaFutures {
+class AkamaiWhitelistFilterWithCustomFailureDefaultSpec extends PlaySpec with TestAppWithCustomFailureDefault with ScalaFutures {
 
   "AkamaiWhitelistFilter" must {
 
-    "return a `NotImplemented` by default when no `True-Client-IP` header is found" in {
-
+    "return the custom response by default when no `True-Client-IP` header is found" in {
       val Some(result) = route(FakeRequest("GET", "/index"))
-      status(result) must be (NOT_IMPLEMENTED)
+      status(result) must be (OK)
+      contentAsString(result) must be ("success")
     }
 
     "return successfully when a valid `True-Client-IP` header is found" in {
-
       val Some(result) = route(FakeRequest("GET", "/index").withHeaders(
         "True-Client-IP" -> "127.0.0.1"
       ))
@@ -41,7 +40,6 @@ class AkamaiWhitelistFilterSpec extends PlaySpec with TestApp with ScalaFutures 
     }
 
     "return a `Redirect` when an invalid `True-Client-IP` header is found" in {
-
       val Some(result) = route(FakeRequest("GET", "/index").withHeaders(
         "True-Client-IP" -> "someotherip"
       ))
@@ -50,7 +48,6 @@ class AkamaiWhitelistFilterSpec extends PlaySpec with TestApp with ScalaFutures 
     }
 
     "return `Forbidden` if the user would end up in a redirect loop" in {
-
       val Some(result) = route(FakeRequest("GET", "/destination").withHeaders(
         "True-Client-IP" -> "someotherip"
       ))
@@ -59,10 +56,9 @@ class AkamaiWhitelistFilterSpec extends PlaySpec with TestApp with ScalaFutures 
     }
 
     "return `Ok` if the route to be accessed is an excluded path" in {
-
       val Some(result) = route(FakeRequest("GET", "/healthcheck"))
-
       status(result) mustBe OK
     }
+
   }
 }

--- a/src/test/scala/uk/gov/hmrc/whitelist/TestAppWithCustomFailureDefault.scala
+++ b/src/test/scala/uk/gov/hmrc/whitelist/TestAppWithCustomFailureDefault.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.whitelist
+
+import org.scalatest.Suite
+import org.scalatestplus.play.OneAppPerSuite
+import play.api.mvc.Results._
+import play.api.mvc._
+import play.api.test.FakeApplication
+
+import scala.concurrent.Future
+
+trait TestAppWithCustomFailureDefault extends OneAppPerSuite {
+  self: Suite =>
+
+  object Global extends WithFilters(new AkamaiWhitelistFilter {
+    override lazy val whitelist: Seq[String] = Seq("127.0.0.1")
+    override lazy val destination: Call = Call("GET", "/destination")
+    override lazy val excludedPaths: Seq[Call] = Seq(Call("GET", "/healthcheck"))
+    override def noHeaderAction(f: (RequestHeader) => Future[Result],
+                                rh: RequestHeader): Future[Result] = f(rh)
+  })
+
+  override implicit lazy val app: FakeApplication = FakeApplication(
+    withGlobal = Some(Global),
+    withRoutes = {
+      case ("GET", "/destination") => Action(Ok("destination"))
+      case ("GET", "/index") => Action(Ok("success"))
+      case ("GET", "/healthcheck") => Action(Ok("ping"))
+    }
+  )
+}


### PR DESCRIPTION
We're building a two-way gateway. Communication needs to be allowed from internal -> frontend -> 3rd party and from 3rd party -> frontend -> internal.

This filter will currently block all internal -> frontend communication (if the filter is on the frontend) because it doesn't have an Akamai header. In practice all the traffic coming to our frontends is via Akamai, so all has the headers, so we should be free to define our own "no header" behaviour (in this case, accept traffic) - which this change would allow us to do.
